### PR TITLE
Issue Fix - Prompt Confirmation on cookies all clear

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,7 +118,6 @@ function onCookieChanged(){
       console.log(cookies);
   });
 }
-
 onCookieChanged();
 
   function clearAllCookies(){
@@ -133,6 +132,28 @@ onCookieChanged();
       setCookieCount();
   }
   
+  function getConfirmation(){
+      document.getElementById("cookie-form").style.display="none";
+      document.getElementById("banner").style.display="none";
+      document.getElementById("confirm").style.display="block";
+
+      var yesButton = document.getElementById("confirm_clear");
+      var noButton = document.getElementById("abort_clear");
+
+      yesButton.addEventListener('click', function() {
+        clearAllCookies();
+        document.getElementById("cookie-form").style.display="block";
+        document.getElementById("banner").style.display="block";
+        document.getElementById("confirm").style.display="none";
+      });
+
+      noButton.addEventListener('click', function() {
+        document.getElementById("cookie-form").style.display="block";
+        document.getElementById("banner").style.display="block";
+        document.getElementById("confirm").style.display="none";
+      });
+
+  }
   function removeCookie(cookie) {
     var url = "http" + (cookie.secure ? "s" : "") + "://" + cookie.domain +
               cookie.path;
@@ -150,7 +171,8 @@ onCookieChanged();
     var url = document.getElementById("url");
     // onClick's logic below:
     clear_Cookies.addEventListener('click', function() {
-        clearAllCookies();
+        getConfirmation();
+        //clearAllCookies();
     });
     set_Cookies.addEventListener('click',function(){
         setCookies();

--- a/index.html
+++ b/index.html
@@ -42,9 +42,19 @@
             <div class="alert alert-info alert-dismissible" id="banner">
                     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
                     <p id="message">Please enter <strong>complete url</strong> below and press <span class='label label-primary'>Display Cookies</span></p>
-                  </div>
-                  <div id="result"></div>
-            <form>
+            </div>
+
+            <div class="alert alert-danger" style="display:none;" id="confirm">
+                    <p id="message"><strong>Warning! </strong> Are you sure? you want to clear all cookies</p>
+                    <hr>
+
+                    <button type="button" class="btn btnBelow btn-warning" id="confirm_clear">Yes</button>
+                    <button type="button" class="btn btnBelow btn-secondary" id="abort_clear">No</button>
+
+            </div>
+
+            <div id="result"></div>
+            <form id="cookie-form">
               <div class="form-group">
                 <label for="url">Enter Domain:</label>
                 <input type="text" class="form-control" id="url" required="required">


### PR DESCRIPTION
###  Prompt a confirmation before clearing all cookies - Issue

When Clear Cookies is clicked, new method getConfirmation will be called. 

**getConfirmation() -->method**

> This methods displays a new alert to user whether they want to clear all cookies or abort. 

1. When the user choose Yes(i,e to clear cookies) clearAllCookies method will be called. 
2. On No the process will be aborted. No cookies will be removed.

**UI Changes**
> New alert box is added with warning message and yes or no button. Initially its hidden. It is shown only when clear cookies is pressed.


![Screenshot from 2021-10-03 21-54-02](https://user-images.githubusercontent.com/52456751/135764382-cdfc05f1-6851-4262-9b1e-d965122f2fcf.png)


> _This is my first ever PR and issue in Github. Any feedback would be appreciated._

If this PR is valid, add ***hacktoberfest-accepted label***